### PR TITLE
bug fix: windows path is case-insensitive.

### DIFF
--- a/src/node/nodeDebug.ts
+++ b/src/node/nodeDebug.ts
@@ -885,7 +885,8 @@ export class NodeDebugSession extends DebugSession {
 						break;
 					case 'scriptName':
 						const script_name: string = breakpoint.script_name;
-						if (script_name === path) {
+						if (script_name === path ||
+							/Windows/.test(require('os').type()) && script_name.toLowerCase() === path.toLowerCase()) {
 							toClear.push(breakpoint.number);
 						}
 						break;


### PR DESCRIPTION
For windows platform paths on host v8 and vscode are different, because path on Windows is case-insensitive.