### PR TITLE
Added browser launching to launch.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 		"vscode-debugadapter": "^1.11.0",
 		"source-map": "^0.5.3",
 		"vscode-nls": "^1.0.4",
-		"request-light": "^0.1.0"
+		"request-light": "^0.1.0",
+		"opn": "^4.0.2"
 	},
 	"repository": {
 		"type": "git",
@@ -157,6 +158,16 @@
 								"type": ["string", "null"],
 								"description": "%node.launch.runtimeExecutable.description%",
 								"default": null
+							},
+							"launchBrowser": {
+								"type": ["string", "null"],
+								"description": "%node.launch.launchBrowser.description%",
+								"default": "http://localhost:3000/"
+							},
+							"browserDelay": {
+								"type": ["string", "number", "null"],
+								"description": "%node.launch.browserDelay.description%",
+								"default": "auto"
 							},
 							"runtimeArgs": {
 								"type": "array",
@@ -287,6 +298,16 @@
 								"type": ["string", "null"],
 								"description": "%extensionHost.launch.runtimeExecutable.description%",
 								"default": "${execPath}"
+							},
+							"launchBrowser": {
+								"type": ["string", "null"],
+								"description": "%extensionHost.launch.launchBrowser.description%",
+								"default": "http://localhost:3000/"
+							},
+							"browserDelay": {
+								"type": ["string", "number", "null"],
+								"description": "%extensionHost.launch.browserDelay.description%",
+								"default": "auto"
 							},
 							"args": {
 								"type": "array",

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,6 +16,8 @@
 	"node.launch.args.description": "Command line arguments passed to the program.",
 	"node.launch.cwd.description": "Absolute path to the working directory of the program being debugged.",
 	"node.launch.runtimeExecutable.description": "Absolute path to the runtime executable to be used. Default is the runtime executable on the PATH.",
+	"node.launch.launchBrowser.description": "Url to open in the default browser on launch.",
+	"node.launch.browserDelay.description": "How long in milliseconds to delay the browser opening. If you set this to \"auto\", it will wait until the http listener has started.",
 	"node.launch.runtimeArgs.description": "Optional arguments passed to the runtime executable.",
 	"node.launch.env.description": "Environment variables passed to the program.",
 
@@ -33,6 +35,8 @@
 	"extensionHost.label": "VSCode Extension Development",
 
 	"extensionHost.launch.runtimeExecutable.description": "Absolute path to VS Code.",
+	"extensionHost.launch.launchBrowser.description": "Url to open default browser to.",
+	"extensionHost.launch.browserDelay.description": "How long to delay browser opening.",
 	"extensionHost.launch.args.description": "Command line arguments passed to the program.",
 	"extensionHost.launch.stopOnEntry.description": "Automatically stop the extension host after launch.",
 	"extensionHost.launch.sourceMaps.description": "Use JavaScript source maps.",

--- a/src/typings/opn.d.ts
+++ b/src/typings/opn.d.ts
@@ -1,0 +1,82 @@
+// Type definitions for opn 3.0.2
+// Project: https://github.com/sindresorhus/opn
+// Definitions by: Shinnosuke Watanabe <https://github.com/shinnn>,
+//                 Maxime LUCE <https://github.com/SomaticIT>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="./node.d.ts" />
+
+declare namespace Opn {
+    export interface Options {
+        /**
+         * Wait for the opened app to exit before calling the `callback`. 
+         * If `false` it's called immediately when opening the app.
+         * On Windows you have to explicitly specify an app for it to be able to wait.
+         */
+        wait?: boolean;
+        
+        /**
+         * Specify the app to open the target with, or an array with the app and app arguments.
+         * The app name is platform dependent. Don't hard code it in reusable modules. 
+         * Eg. Chrome is `google chrome` on OS X, `google-chrome` on Linux and `chrome` on Windows.
+         */
+        app?: string | string[];
+    }
+}
+
+declare module "opn" {
+    import * as cp from "child_process";
+
+    interface DefaultFunction {
+        /**
+         * Uses the command open on OS X, start on Windows and xdg-open on other platforms.
+         * 
+         * Returns the spawned child process. 
+         * You'd normally not need to use this for anything, but it can be useful if you'd like 
+         * to attach custom event listeners or perform other operations directly on the spawned process.
+         * 
+         * @param target - The thing you want to open. Can be a URL, file, or executable. Opens in the default app for the file type. Eg. URLs opens in your default browser.
+         */
+        (target: string): cp.ChildProcess;
+
+        /**
+         * Uses the command open on OS X, start on Windows and xdg-open on other platforms.
+         * 
+         * Returns the spawned child process. 
+         * You'd normally not need to use this for anything, but it can be useful if you'd like 
+         * to attach custom event listeners or perform other operations directly on the spawned process.
+         * 
+         * @param target - The thing you want to open. Can be a URL, file, or executable. Opens in the default app for the file type. Eg. URLs opens in your default browser.
+         * @param callback- Called when the opened app exits, or if `wait: false`, immediately when opening.
+         */
+        (target: string, callback: (err: Error) => void): cp.ChildProcess;
+
+        /**
+         * Uses the command open on OS X, start on Windows and xdg-open on other platforms.
+         * 
+         * Returns the spawned child process. 
+         * You'd normally not need to use this for anything, but it can be useful if you'd like 
+         * to attach custom event listeners or perform other operations directly on the spawned process.
+         * 
+         * @param target - The thing you want to open. Can be a URL, file, or executable. Opens in the default app for the file type. Eg. URLs opens in your default browser.
+         * @param options - Options to be passed to opn.
+         */
+        (target: string, options: Opn.Options): cp.ChildProcess;
+
+        /**
+         * Uses the command open on OS X, start on Windows and xdg-open on other platforms.
+         * 
+         * Returns the spawned child process. 
+         * You'd normally not need to use this for anything, but it can be useful if you'd like 
+         * to attach custom event listeners or perform other operations directly on the spawned process.
+         * 
+         * @param target - The thing you want to open. Can be a URL, file, or executable. Opens in the default app for the file type. Eg. URLs opens in your default browser.
+         * @param options - Options to be passed to opn.
+         * @param callback- Called when the opened app exits, or if `wait: false`, immediately when opening.
+         */
+        (target: string, options: Opn.Options, callback: (err: Error) => void): cp.ChildProcess;
+    }
+
+    const opn: DefaultFunction;
+    export = opn;
+}


### PR DESCRIPTION
This adds two options to launch.json.

`launchBrowser` -> URL that opens in a browser on project launch.
`browserDelay` -> Number of milliseconds to delay the browser opening.  This can be set to "auto" to automatically launch when the http port is open.  This is useful for projects that take a moment to start up.
