### PR TITLE
fix japanese localization of "closure" from "閉じる" ("close") to "クロージャ" ("closure")

### DIFF
--- a/i18n/jpn/out/node/nodeDebug.i18n.json
+++ b/i18n/jpn/out/node/nodeDebug.i18n.json
@@ -46,7 +46,7 @@
 	"reason.user_request": "ユーザー要求",
 	"scope.block": "ブロック ",
 	"scope.catch": "Catch",
-	"scope.closure": "閉じる",
+	"scope.closure": "クロージャ",
 	"scope.exception": "例外",
 	"scope.global": "グローバル",
 	"scope.local": "ローカル",


### PR DESCRIPTION
- fix japanese localization of "closure" from "閉じる" ("close") to "クロージャ" ("closure")
