### PR TITLE
Added Transifex support for localisations

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,6 +39,22 @@ var scripts2 = [
 
 var outDest = 'out';
 
+const transifexApiHostname = 'www.transifex.com'
+const transifexApiName = 'api';
+const transifexApiToken = process.env.TRANSIFEX_API_TOKEN;
+const transifexProjectName = 'vscode-extensions';
+const transifexExtensionName = 'vscode-node-debug';
+const vscodeLanguages = [
+	'zh-hans',
+	'zh-hant',
+	'ja',
+	'ko',
+	'de',
+	'fr',
+	'es',
+	'ru',
+	'it'
+];
 
 gulp.task('default', function(callback) {
 	runSequence('build', callback);
@@ -124,6 +140,14 @@ gulp.task('add-i18n', function() {
 	return gulp.src(['package.nls.json'])
 		.pipe(nls.createAdditionalLanguageFiles(nls.coreLanguages, 'i18n'))
 		.pipe(gulp.dest('.'));
+});
+
+gulp.task('transifex-push', function() {
+	return gulp.src('**/*.nls.json').pipe(nls.prepareXlfFiles(transifexProjectName, transifexExtensionName)).pipe(nls.pushXlfFiles(transifexApiHostname, transifexApiName, transifexApiToken));
+});
+
+gulp.task('transifex-pull', function() {
+	return nls.pullXlfFiles(transifexApiHostname, transifexApiName, transifexApiToken, vscodeLanguages, [{ name: transifexExtensionName, project: transifexProjectName }]).pipe(nls.prepareJsonFiles()).pipe(gulp.dest('./i18n'));
 });
 
 gulp.task('vsce-publish', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -143,11 +143,15 @@ gulp.task('add-i18n', function() {
 });
 
 gulp.task('transifex-push', function() {
-	return gulp.src('**/*.nls.json').pipe(nls.prepareXlfFiles(transifexProjectName, transifexExtensionName)).pipe(nls.pushXlfFiles(transifexApiHostname, transifexApiName, transifexApiToken));
+	return gulp.src('**/*.nls.json')
+		.pipe(nls.prepareXlfFiles(transifexProjectName, transifexExtensionName))
+		.pipe(nls.pushXlfFiles(transifexApiHostname, transifexApiName, transifexApiToken));
 });
 
 gulp.task('transifex-pull', function() {
-	return nls.pullXlfFiles(transifexApiHostname, transifexApiName, transifexApiToken, vscodeLanguages, [{ name: transifexExtensionName, project: transifexProjectName }]).pipe(nls.prepareJsonFiles()).pipe(gulp.dest('./i18n'));
+	return nls.pullXlfFiles(transifexApiHostname, transifexApiName, transifexApiToken, vscodeLanguages, [{ name: transifexExtensionName, project: transifexProjectName }])
+		.pipe(nls.prepareJsonFiles())
+		.pipe(gulp.dest('./i18n'));
 });
 
 gulp.task('vsce-publish', function() {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"tslint": "^3.15.1",
 		"typescript": "^2.2.1",
 		"vscode": "^1.0.3",
-		"vscode-nls-dev": "^2.0.1",
+		"vscode-nls-dev": "^2.1.1",
 		"vscode-debugadapter-testsupport": "^1.18.0",
 		"vscode-debugprotocol": "^1.18.0",
 		"event-stream": "^3.3.4",


### PR DESCRIPTION
Introduces ability to convert .nls.json to .xlf files and translations push/pull from Transifex. Pull will drop translations from Transifex to `i18n` folder.