### PR TITLE
Split Transifex pull and i18n import task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,6 +150,11 @@ gulp.task('transifex-push', function() {
 
 gulp.task('transifex-pull', function() {
 	return nls.pullXlfFiles(transifexApiHostname, transifexApiName, transifexApiToken, vscodeLanguages, [{ name: transifexExtensionName, project: transifexProjectName }])
+		.pipe(gulp.dest(`../${transifexExtensionName}-localization`));
+});
+
+gulp.task('i18n-import', function() {
+	return gulp.src(`../${transifexExtensionName}-localization/**/*.xlf`)
 		.pipe(nls.prepareJsonFiles())
 		.pipe(gulp.dest('./i18n'));
 });


### PR DESCRIPTION
Split pull and import task, because translation team will run PoliCheck process on XLF files pulled from Transifex, and only then import localisations with a separate task.

Let me know if you have any questions.