### PR TITLE
Allow local/remote root for launch configuration as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,6 +402,16 @@
 								"type": ["boolean", "string"],
 								"description": "%trace.description%",
 								"default": true
+							},
+							"localRoot": {
+								"type": ["string", "null"],
+								"description": "%node.attach.localRoot.description%",
+								"default": null
+							},
+							"remoteRoot": {
+								"type": ["string", "null"],
+								"description": "%node.attach.remoteRoot.description%",
+								"default": null
 							}
 						}
 					},

--- a/src/node/nodeDebug.ts
+++ b/src/node/nodeDebug.ts
@@ -290,6 +290,10 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments, C
 	externalConsole?: boolean;
 	/** Where to launch the debug target. */
 	console?: ConsoleType;
+	/** Optional: Node's root directory. */
+	remoteRoot?: string;
+	/** Optional: VS Code's root directory. */
+	localRoot?: string;
 
 	/** internal */
 	__restart?; boolean;
@@ -829,6 +833,11 @@ export class NodeDebugSession extends LoggingDebugSession {
 		}
 
 		const port = args.port || random(3000, 50000);
+
+		if (args.localRoot && args.remoteRoot) {
+			this._localRoot = args.localRoot;
+			this._remoteRoot = args.remoteRoot;
+		}
 
 		let runtimeExecutable = args.runtimeExecutable;
 		if (runtimeExecutable) {


### PR DESCRIPTION
Hi, I develop with different node configurations / environments using docker containers, often. It is quite convenient to start the node installation inside the docker with a launch configuration as you still see the console output in vscode. However, because it is technically a remote setup with a different source path, a readonly version of the Javascript source gets opened during debugging. Therefore, I kindly ask to enable the options "localRoot" and "remoteRoot" from attach configuration for launch configurations as well.

Thank you and kind regards,
Tobias