### PR TITLE
Add support for Windows Subsystem Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -403,6 +403,11 @@
 								"type": ["boolean", "string"],
 								"description": "%trace.description%",
 								"default": true
+							},
+							"useWSL": {
+								"type": "boolean",
+								"description": "%node.launch.useWSL.description%",
+								"default": false
 							}
 						}
 					},

--- a/package.nls.json
+++ b/package.nls.json
@@ -41,6 +41,7 @@
 	"node.launch.runtimeArgs.description": "Optional arguments passed to the runtime executable.",
 	"node.launch.env.description": "Environment variables passed to the program.",
 	"node.launch.envFile.description": "Absolute path to a file containing environment variable definitions.",
+	"node.launch.useWSL.description": "Use Windows Subsystem Linux.",
 
 	"node.launch.config.name": "Launch",
 

--- a/src/tests/adapter.test.ts
+++ b/src/tests/adapter.test.ts
@@ -5,6 +5,7 @@
 
 import assert = require('assert');
 import * as Path from 'path';
+import * as FS from 'fs';
 import {DebugProtocol} from 'vscode-debugprotocol';
 import {DebugClient} from 'vscode-debugadapter-testsupport';
 
@@ -72,6 +73,21 @@ suite('Node Debug Adapter', () => {
 				dc.waitForEvent('terminated')
 			]);
 		});
+
+		if (process.platform === 'win32') {
+			const bash32bitPath = Path.join(process.env.SystemRoot, 'SYSNATIVE', 'bash.exe');
+			const bash64bitPath = Path.join(process.env.SystemRoot, 'System32', 'bash.exe');
+			if (FS.existsSync(bash32bitPath) || FS.existsSync(bash64bitPath)) {
+				test('should run program using subsystem linux', () => {
+					const PROGRAM = Path.join(DATA_ROOT, 'program.js');
+					return Promise.all([
+						dc.configurationSequence(),
+						dc.launch({ program: PROGRAM, useWSL: true }),
+						dc.waitForEvent('terminated')
+					]);
+				});
+			}
+		}
 
 		test('should stop on entry', () => {
 


### PR DESCRIPTION
Add a new `useWSL` boolean attribute to launch arguments. If set to true, debugger will launch Node.js (or given `runtimeExecutable`) using Windows Subsystem Linux.

When the debugger is instructed to use Linux subsystem it will first test if it is installed. This is done by  checking if `%WINDIR%\System32\bash.exe` (for 64-bit VS Code) or `%WINDIR%\SYSNATIVE\bash.exe` (for 32-bit VS Code) is present. If found, it is then used as `runtimeExecutable`, with user-specified `runtimeExecutable` (with all appropriate parameters) passed as the command to execute (using bash `-c` parameter). Mapping of the source filenames (the `localRoot` and `remoteRoot` attributes) is also automatically adjusted.

For best results, this should be used together with `useWSL` implementation for the `inspector` protocol (https://github.com/Microsoft/vscode-node-debug2/pull/126)

/cc @yodurr
