### PR TITLE
Accept .mjs as a valid fileending

### DIFF
--- a/src/node/nodeDebug.ts
+++ b/src/node/nodeDebug.ts
@@ -4018,7 +4018,7 @@ export class NodeDebugSession extends LoggingDebugSession {
 	private static isJavaScript(path: string): boolean {
 
 		const name = Path.basename(path).toLowerCase();
-		if (endsWith(name, '.js')) {
+		if (endsWith(name, '.js') || endsWith(name, '.mjs')) {
 			return true;
 		}
 


### PR DESCRIPTION
Fix for not beeing able to debug a `.mjs` file in Code. See 
Microsoft/vscode#33051 for more details.