### PR TITLE
Treat Breakpoint logMessage as expression

### DIFF
--- a/src/node/nodeDebug.ts
+++ b/src/node/nodeDebug.ts
@@ -201,7 +201,7 @@ class InternalSourceBreakpoint {
 		this.column = this.orgColumn = column;
 
 		if (logMessage) {
-			this.condition = `console.log('${logMessage}')`;
+			this.condition = `console.log(${logMessage})`;
 			if (condition) {
 				this.condition = `(${condition}) && ${this.condition}`;
 			}


### PR DESCRIPTION
Change LogPoints's logMessage to be evaluated as an expression and not a string, so LogPoints like `LogPoint('products', products)` can be set.