### PR TITLE
Enable Loaded Scripts for VS Live Share

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 				{
 					"id": "extension.node-debug.loadedScriptsExplorer",
 					"name": "%loaded.scripts.view.name%",
-					"when": "inDebugMode && debugType =~ /^(node|node2|extensionHost|chrome)$/"
+					"when": "inDebugMode && showLoadedScriptsExplorer"
 				}
 			]
 		},

--- a/src/node/extension/loadedScripts.ts
+++ b/src/node/extension/loadedScripts.ts
@@ -89,8 +89,12 @@ export class LoadedScriptsProvider implements TreeDataProvider<BaseTreeItem> {
 
 	private async isSupportedDebugType(debugType: string | undefined, session: vscode.DebugSession): Promise<boolean> {
 		if (debugType === 'vslsShare') {
-			const debugSessionInfo = session ? await session.customRequest('debugSessionInfo', {}) : undefined;
-			debugType = (debugSessionInfo && debugSessionInfo.configurationProperties) ? debugSessionInfo.configurationProperties.type : undefined;
+			try {
+				const debugSessionInfo = session ? await session.customRequest('debugSessionInfo', {}) : undefined;
+				debugType = (debugSessionInfo && debugSessionInfo.configurationProperties) ? debugSessionInfo.configurationProperties.type : undefined;
+			}
+			catch (e) {
+			}
 		}
 		return debugType === 'node' || debugType === 'node2' || debugType === 'extensionHost' || debugType === 'chrome';
 	}

--- a/src/node/extension/loadedScripts.ts
+++ b/src/node/extension/loadedScripts.ts
@@ -46,12 +46,12 @@ export class LoadedScriptsProvider implements TreeDataProvider<BaseTreeItem> {
 	readonly onDidChangeTreeData: Event<BaseTreeItem> = this._onDidChangeTreeData.event;
 
 	constructor(context: vscode.ExtensionContext) {
-
 		this._root = new RootTreeItem();
 
-		context.subscriptions.push(vscode.debug.onDidStartDebugSession(session => {
+		context.subscriptions.push(vscode.debug.onDidStartDebugSession(async (session: vscode.DebugSession): Promise<void> => {
 			const t = session ? session.type : undefined;
-			if (t === 'node' || t === 'node2' || t === 'extensionHost' || t === 'chrome') {
+			if (await this.isSupportedDebugType(t, session)) {
+				vscode.commands.executeCommand('setContext', 'showLoadedScriptsExplorer', true);
 				this._root.add(session);
 				this._onDidChangeTreeData.fire(undefined);
 			}
@@ -59,13 +59,10 @@ export class LoadedScriptsProvider implements TreeDataProvider<BaseTreeItem> {
 
 		let timeout: NodeJS.Timer;
 
-		context.subscriptions.push(vscode.debug.onDidReceiveDebugSessionCustomEvent(event => {
-
+		context.subscriptions.push(vscode.debug.onDidReceiveDebugSessionCustomEvent(async (event): Promise<void> => {
 			const t = (event.event === 'loadedSource' && event.session) ? event.session.type : undefined;
-			if (t === 'node' || t === 'node2' || t === 'extensionHost' || t === 'chrome') {
-
+			if (await this.isSupportedDebugType(t, event.session)) {
 				const sessionRoot = this._root.add(event.session);
-
 				sessionRoot.addPath(<Source> event.body.source);
 
 				clearTimeout(timeout);
@@ -88,6 +85,14 @@ export class LoadedScriptsProvider implements TreeDataProvider<BaseTreeItem> {
 
 	getTreeItem(node: BaseTreeItem): TreeItem {
 		return node;
+	}
+
+	private async isSupportedDebugType(debugType: string | undefined, session: vscode.DebugSession): Promise<boolean> {
+		if (debugType === 'vslsShare') {
+			const debugSessionInfo = session ? await session.customRequest('debugSessionInfo', {}) : undefined;
+			debugType = (debugSessionInfo && debugSessionInfo.configurationProperties) ? debugSessionInfo.configurationProperties.type : undefined;
+		}
+		return debugType === 'node' || debugType === 'node2' || debugType === 'extensionHost' || debugType === 'chrome';
 	}
 }
 

--- a/src/node/extension/loadedScripts.ts
+++ b/src/node/extension/loadedScripts.ts
@@ -90,8 +90,7 @@ export class LoadedScriptsProvider implements TreeDataProvider<BaseTreeItem> {
 	private async isSupportedDebugType(debugType: string | undefined, session: vscode.DebugSession): Promise<boolean> {
 		if (debugType === 'vslsShare') {
 			try {
-				const debugSessionInfo = session ? await session.customRequest('debugSessionInfo', {}) : undefined;
-				debugType = (debugSessionInfo && debugSessionInfo.configurationProperties) ? debugSessionInfo.configurationProperties.type : undefined;
+				debugType = session ? await session.customRequest('debugType', {}) : undefined;
 			}
 			catch (e) {
 			}


### PR DESCRIPTION
Enable Loaded Scripts for VS Live Share

Issue: When VS LiveShare is installed the Loaded Scripts pane no longer shows up when the host is debugging, irrespective of if they are sharing or not.  This is because the debugType is 'vslsShare' instead of one of the known supported types.

Fix: When the debug type is 'vslsShare' attempt to retrieve the real debug type from the custom debugSessionInfo's configurationProperties.  