### PR TITLE
"Open loaded script" to properly open file Sources

### DIFF
--- a/src/node/extension/loadedScripts.ts
+++ b/src/node/extension/loadedScripts.ts
@@ -81,15 +81,18 @@ function listLoadedScripts(session: vscode.DebugSession | undefined): Thenable<S
 }
 
 export function openScript(session: vscode.DebugSession | undefined, source: Source) {
-	let debug = `debug:${encodeURIComponent(source.path)}`;
-	let sep = '?';
-	if (session) {
-		debug += `${sep}session=${encodeURIComponent(session.id)}`;
-		sep = '&';
-	}
+	let uri: vscode.Uri;
 	if (source.sourceReference) {
+		let debug = `debug:${encodeURIComponent(source.path)}`;
+		let sep = '?';
+		if (session) {
+			debug += `${sep}session=${encodeURIComponent(session.id)}`;
+			sep = '&';
+		}
 		debug += `${sep}ref=${source.sourceReference}`;
+		uri = vscode.Uri.parse(debug);
+	} else {
+		uri = vscode.Uri.file(source.path);
 	}
-	let uri = vscode.Uri.parse(debug);
 	vscode.workspace.openTextDocument(uri).then(doc => vscode.window.showTextDocument(doc));
 }


### PR DESCRIPTION
@weinand Could you please take a look?

When [DAP Source](https://microsoft.github.io/debug-adapter-protocol/specification#Types_Source) does not have `sourceReference`, it should be opened using its `path` property, like a regular file. Open loaded script functionality did not honor this, and always opened through debug uri, which makes a file read-only.

Steps to test:
1. Open [this](https://github.com/microsoft/vscode-pwa/tree/master/demos/node-ts) folder.
2. Run "Launch Program".
3. Ctrl+Shit+P, "Debug: Open Loaded Script", type index.js, hit Enter.
4. index.js opens as a regular file (editable, points to nodes-ts/out/index.js).