### PR TITLE
Conflict on keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,11 +130,7 @@
 				"mac": "F10",
 				"when": "!inDebugMode && debugConfigurationType=='node'"
 			},
-			{
-				"command": "extension.node-debug.startWithStopOnEntry",
-				"mac": "F11",
-				"when": "!inDebugMode && debugConfigurationType=='node'"
-			}
+			
 		],
 		"breakpoints": [
 			{


### PR DESCRIPTION
"command": "extension.node-debug.startWithStopOnEntry" has two conflicts with the keys **F10** & **F11** on Mac OS.